### PR TITLE
Add Amplitude tracking for KPI events

### DIFF
--- a/app/adventures/[adventureId]/page.tsx
+++ b/app/adventures/[adventureId]/page.tsx
@@ -1,3 +1,4 @@
+import { AdventureDescription } from "@/components/adventures/adventure-description";
 import AdventureDetails from "@/components/adventures/adventure-details";
 import AdventureTag from "@/components/adventures/adventure-tag";
 import CharacterTemplatesSection from "@/components/adventures/character-templates-section";
@@ -5,7 +6,6 @@ import EmojiPicker from "@/components/adventures/emoji-picker";
 import { Button } from "@/components/ui/button";
 import { TypographyH1 } from "@/components/ui/typography/TypographyH1";
 import { TypographyLarge } from "@/components/ui/typography/TypographyLarge";
-import { TypographyMuted } from "@/components/ui/typography/TypographyMuted";
 import { getAdventure } from "@/lib/adventure/adventure.server";
 import prisma from "@/lib/db";
 import { auth } from "@clerk/nextjs";
@@ -195,12 +195,10 @@ export default async function AdventurePage({
       <div className="p-4 md:p-6 flex gap-6 flex-col">
         <div>
           <TypographyH1>{adventure.name}</TypographyH1>
-          <TypographyLarge className="mt-2 text-2xl">
+          <TypographyLarge className="mt-2 text-xl">
             {adventure.shortDescription}
           </TypographyLarge>
-          <TypographyMuted className="mt-2 text-2xl whitespace-break-spaces">
-            {adventure.description}
-          </TypographyMuted>
+          <AdventureDescription description={adventure.description} />
         </div>
         <CharacterTemplatesSection adventure={adventure} />
         <AdventureDetails adventure={adventure} />

--- a/components/adventures/adventure-description.tsx
+++ b/components/adventures/adventure-description.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { TypographyMuted } from "../ui/typography/TypographyMuted";
+
+export const AdventureDescription = ({
+  description,
+}: {
+  description: string;
+}) => {
+  const [isClamped, setIsClamped] = useState(true);
+
+  return (
+    <div className="relative inline">
+      <TypographyMuted
+        className={cn(
+          "mt-2 text-xl whitespace-break-spaces",
+          isClamped && "line-clamp-2"
+        )}
+      >
+        {description}
+      </TypographyMuted>
+      <button
+        className="text-primary text-lg hover:underline"
+        onClick={() => setIsClamped((c) => !c)}
+      >
+        View {isClamped ? "more" : "less"}
+      </button>
+    </div>
+  );
+};

--- a/components/adventures/character-map.tsx
+++ b/components/adventures/character-map.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { amplitude } from "@/lib/amplitude";
 import { Character } from "@/lib/game/schema/characters";
 import { track } from "@vercel/analytics/react";
 import Image from "next/image";
@@ -34,6 +35,13 @@ const CharacterMap = ({
               }
               className="flex h-full text-center w-full relative rounded-md aspect-[1/1] md:aspect-[1/1.5]  overflow-hidden border border-foreground/20 hover:border-indigo-500"
               onClick={() => {
+                amplitude.track("Button Click", {
+                  buttonName: "Start Adventure",
+                  location: "Adventure",
+                  action: "start-adventure",
+                  adventureId: adventureId,
+                  templateCharacter: true,
+                });
                 track("Character Selected", {
                   character: character.name,
                 });

--- a/components/adventures/character-templates-section.tsx
+++ b/components/adventures/character-templates-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Button } from "@/components/ui/button";
+import { amplitude } from "@/lib/amplitude";
 import { Character } from "@/lib/game/schema/characters";
 import { Adventure } from "@prisma/client";
 import Link from "next/link";
@@ -34,6 +35,15 @@ const CharacterTemplatesSection = ({ adventure }: { adventure: Adventure }) => {
     </TypographyMuted>
   );
   console.log(adventure);
+  const onClick = async () => {
+    amplitude.track("Button Click", {
+      buttonName: "Start Adventure",
+      location: "Adventure",
+      action: "start-adventure",
+      adventureId: adventure.id,
+      templateCharacter: false,
+    });
+  };
   return (
     <>
       {hasPremadeCharacters && (
@@ -57,7 +67,7 @@ const CharacterTemplatesSection = ({ adventure }: { adventure: Adventure }) => {
         </TypographyH2>
         {createDescription}
         <div className="mt-2">
-          <Button asChild className="text-xl py-6 px-6 mt-2">
+          <Button asChild className="text-xl py-6 px-6 mt-2" onClick={onClick}>
             <Link href={`/adventures/${adventure.id}/create-instance`}>
               Create a {playerSingularNoun.toLocaleLowerCase()}
             </Link>

--- a/components/adventures/character-templates-section.tsx
+++ b/components/adventures/character-templates-section.tsx
@@ -35,7 +35,7 @@ const CharacterTemplatesSection = ({ adventure }: { adventure: Adventure }) => {
     </TypographyMuted>
   );
   console.log(adventure);
-  const onClick = async () => {
+  const onClick = () => {
     amplitude.track("Button Click", {
       buttonName: "Start Adventure",
       location: "Adventure",

--- a/components/adventures/create-adventure-button.tsx
+++ b/components/adventures/create-adventure-button.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { amplitude } from "@/lib/amplitude";
 import { Adventure } from "@prisma/client";
 import { useRouter } from "next/navigation";
 import { Button } from "../ui/button";
@@ -15,6 +16,12 @@ export const CreateAdventureButton = () => {
     });
     if (res.ok && res.status === 201) {
       const { adventure } = (await res.json()) as { adventure: Adventure };
+      amplitude.track("Button Click", {
+        buttonName: "Create Adventure",
+        location: "Editor",
+        action: "create-adventure",
+        adventureId: adventure.id,
+      });
       router.push(`/adventures/editor/${adventure.id}`);
     }
   };

--- a/components/camp/quest-progress.tsx
+++ b/components/camp/quest-progress.tsx
@@ -90,11 +90,6 @@ const QuestProgressElement = ({
 
     setIsVisible(true);
     setIsLoading(true);
-    amplitude.track("Button Click", {
-      buttonName: "Go on an Adventure",
-      location: "Camp",
-      action: "start-quest",
-    });
 
     // If the game state says we're currently in a quest, then we should re-direct ot that quest.
     if (gameState?.active_mode === "quest" && gameState?.current_quest) {
@@ -126,6 +121,7 @@ const QuestProgressElement = ({
     const json = (await resp.json()) as {
       quest: Quest & { status: { state: string; statusMessage: string } };
     };
+
     if (json?.quest?.status?.state === "failed") {
       setIsLoading(false);
       setIsVisible(false);
@@ -142,7 +138,14 @@ const QuestProgressElement = ({
       log.error(`Failed to get QuestId: ${JSON.stringify(json)}`);
       return;
     }
-
+    amplitude.track("Button Click", {
+      buttonName: "Go on an Adventure",
+      location: "Camp",
+      action: "start-quest",
+      adventureId: "TODO",
+      workspaceHandle: params.handle,
+      questId: questId,
+    });
     log.debug(`Activating new quest: ${questId}`);
     router.push(`/play/${params.handle}/quest/${questId}`);
     setIsLoading(false);

--- a/components/editor/publish-button.tsx
+++ b/components/editor/publish-button.tsx
@@ -25,6 +25,7 @@ const PublishButton = ({
       buttonName: "Publish Adventure",
       location: "Editor",
       action: "publish-adventure",
+      adventureId: adventureId,
     });
 
     const resp = await fetch(`/api/adventure/${adventureId}`, {

--- a/components/editor/setting-group-form.tsx
+++ b/components/editor/setting-group-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { amplitude } from "@/lib/amplitude";
 import { SettingGroup } from "@/lib/editor/editor-options";
 import { useEditorRouting } from "@/lib/editor/use-editor";
 import { Block } from "@/lib/streaming-client/src";
@@ -319,6 +320,12 @@ export default function SettingGroupForm({
   };
 
   const onSave = (e: any) => {
+    amplitude.track("Button Click", {
+      buttonName: "Save Adventure",
+      location: "Editor",
+      action: "save-adventure",
+      adventureId: adventureId,
+    });
     mutate(dataToUpdate);
   };
 

--- a/components/editor/test-button.tsx
+++ b/components/editor/test-button.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { amplitude } from "@/lib/amplitude";
 import { useEditorRouting } from "@/lib/editor/use-editor";
 import { RocketIcon } from "lucide-react";
 import Link from "next/link";
@@ -9,9 +10,19 @@ const TestButton = ({ className = "" }: { className?: string }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { adventureId } = useEditorRouting();
 
+  const onClick = async () => {
+    amplitude.track("Button Click", {
+      buttonName: "Test Adventure",
+      location: "Editor",
+      action: "test-adventure",
+      adventureId: adventureId,
+    });
+  };
+
   return (
     <Button
       isLoading={isLoading}
+      onClick={onClick}
       disabled={isLoading}
       className={`${className}`}
     >

--- a/components/quest/quest-narrative/index.tsx
+++ b/components/quest/quest-narrative/index.tsx
@@ -9,6 +9,7 @@ import { QuestNarrativeContainer } from "@/components/quest/shared/components";
 import { inputClassNames } from "@/components/ui/input";
 import { TypographyH3 } from "@/components/ui/typography/TypographyH3";
 import { TypographyP } from "@/components/ui/typography/TypographyP";
+import { amplitude } from "@/lib/amplitude";
 import { getGameState } from "@/lib/game/game-state.client";
 import { useBackgroundMusic } from "@/lib/hooks";
 import { Block } from "@/lib/streaming-client/src";
@@ -328,6 +329,13 @@ export default function QuestNarrative({
               <Button
                 disabled={!isContinuationEnabled}
                 onClick={() => {
+                  amplitude.track("Button Click", {
+                    buttonName: "Continue",
+                    location: "Quest",
+                    action: "continue-quest",
+                    questId: id,
+                    workspaceHandle: params.handle,
+                  });
                   if (initialBlock?.id) {
                     const containsInitialBlock = chatHistory.includes(
                       initialBlock?.id

--- a/components/quest/quest-narrative/narration-player.tsx
+++ b/components/quest/quest-narrative/narration-player.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { amplitude } from "@/lib/amplitude";
 import { useQuery } from "@tanstack/react-query";
 import { PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
 import { useParams } from "next/navigation";
@@ -35,6 +36,16 @@ export function NarrationPlayer({ blockId }: { blockId: string }) {
         size="sm"
         disabled={!url || state.buffered.length === 0}
         onClick={() => {
+          if (!didPlay) {
+            amplitude.track("Button Click", {
+              buttonName: "Play Narration",
+              location: "Quest",
+              action: "play-narration",
+              questId: params.questId,
+              workspaceHandle: params.handle,
+              blockId: blockId,
+            });
+          }
           setDidPlay(true);
           if (state.playing) {
             controls.pause();

--- a/components/quest/shared/end-sheet.tsx
+++ b/components/quest/shared/end-sheet.tsx
@@ -14,6 +14,7 @@ import { TypographyH3 } from "@/components/ui/typography/TypographyH3";
 import { TypographyLarge } from "@/components/ui/typography/TypographyLarge";
 import { TypographyMuted } from "@/components/ui/typography/TypographyMuted";
 import { TypographySmall } from "@/components/ui/typography/TypographySmall";
+import { amplitude } from "@/lib/amplitude";
 import { getGameState } from "@/lib/game/game-state.client";
 import { GameState } from "@/lib/game/schema/game_state";
 import { Quest } from "@/lib/game/schema/quest";
@@ -133,10 +134,29 @@ const EndSheet = ({
   );
   twitterLink.searchParams.set("url", sharePage.toString());
 
+  const onCompleteButtonClick = async () => {
+    // This is a dubious way to determine if this is the first
+    // time this quest has been completed, but I could not find
+    // anything else appropriate in the state to key from
+    if (completeButtonText === "Complete Quest") {
+      amplitude.track("Button Click", {
+        buttonName: "Complete Quest",
+        location: "Quest",
+        action: "complete-quest",
+        questId: params.questId,
+        workspaceHandle: params.handle,
+      });
+    }
+  };
+
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant={isEnd ? "default" : "ghost"} className="w-full">
+        <Button
+          variant={isEnd ? "default" : "ghost"}
+          className="w-full"
+          onClick={onCompleteButtonClick}
+        >
           {completeButtonText}
         </Button>
       </SheetTrigger>


### PR DESCRIPTION

This PR implements most of the desired events and properties specified here:

https://www.notion.so/steamship/Metrics-a2919a6fa71b458e8df6b330ad09f118?pvs=4#c76f55beb3c24d758dc4abc1d219f9c6

Missing: the link between the adventure template's id (stored as `adventureId` to match the web code) and the adventure instance.  It was unclear to me how to do this.