### PR TITLE
Permit an agent version to track `latest`

### DIFF
--- a/lib/editor/DEPRECATED-editor-options.ts
+++ b/lib/editor/DEPRECATED-editor-options.ts
@@ -123,7 +123,7 @@ export function getTopLevelUpdatesFromAdventureConfig(agentConfig: any) {
 
   if (
     agentConfig["game_engine_version"] &&
-    agentConfig["game_engine_version"].startsWith("ai-adventure@")
+    agentConfig["game_engine_version"].startsWith("ai-adventure")
   ) {
     topLevelUpdates["agentVersion"] = agentConfig["game_engine_version"];
   }


### PR DESCRIPTION
Note that if the latest version has a new schema, the developer will need to go through the hoop of artificially setting a new version to force re-creation of the development agent which provides the schema